### PR TITLE
Fix sliding window mask size in one_file_ref.py 

### DIFF
--- a/one_file_ref.py
+++ b/one_file_ref.py
@@ -258,7 +258,7 @@ class Transformer(nn.Module):
             )
             mask = torch.tril(tensor, diagonal=0).to(h.dtype)
             # make the mask banded to account for sliding window
-            mask = torch.triu(mask, diagonal=-self.args.sliding_window)
+            mask = torch.triu(mask, diagonal=-self.args.sliding_window+1)
             mask = torch.log(mask)
         
         for layer in self.layers:


### PR DESCRIPTION
Fixed a minor encoding error in the mask matrix size in one_file_ref.py where the original mask would display one more column than expected size.