### PR TITLE
fix: Correct typo in classifier.ipynb from "alborithm" to "algorithm"

### DIFF
--- a/tutorials/classifier.ipynb
+++ b/tutorials/classifier.ipynb
@@ -355,7 +355,7 @@
    "source": [
     "We can now train the classifier. We will use the [LogisticRegression](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LogisticRegression.html) object of Scikit-learn.\n",
     "\n",
-    "The default learning alborithm is `lbfgs`, which should give an accuracy of 98.33% for this particular train/test split.\n",
+    "The default learning algorithm is `lbfgs`, which should give an accuracy of 98.33% for this particular train/test split.\n",
     "\n",
     "You can try different algorithms, and hyper-parameters. In a real-life scenario, it is possible to obtain better results by using k-fold cross-validation methods to validate accuracy and choice of the hyperparameters."
    ]


### PR DESCRIPTION
Corrected a typo in the markdown cell of the file classifier.ipynb where "alborithm" was incorrectly spelled. The correct term is "algorithm".