### PR TITLE
Fix: grammar in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Guardrailing: [https://docs.mistral.ai/usage/guardrailing](https://docs.mistral.
 
 ## Installation
 
-Note: You will use a GPU to install `mistral-inference`, as it currently requires `xformers` to be installed and `xformers` itself needs a GPU for installation.
+Note: You will need a GPU to install `mistral-inference`, as it currently requires `xformers` to be installed and `xformers` itself needs a GPU for installation.
 
 ### PyPI
 


### PR DESCRIPTION
- Changed "You will *use* a GPU to install" to "You will *need* a GPU to install" for clarity.
  - Justification: "Need" clearly indicates a requirement, improving user guidance.