### PR TITLE
fix: Correct misspelling in ModelArgs docstring

### DIFF
--- a/moe_one_file_ref.py
+++ b/moe_one_file_ref.py
@@ -33,7 +33,7 @@ class ModelArgs(Serializable):
     vocab_size: int
     moe: MoeArgs
 
-    # For rotary embeddings. If not set, will be infered
+    # For rotary embeddings. If not set, will be inferred
     rope_theta: Optional[float] = None
 
     max_batch_size: int = 0


### PR DESCRIPTION
- Fixed the misspelling of "inferred" in the ModelArgs docstring.
- Changed "infered" to "inferred" to maintain proper spelling and clarity in the documentation.