### PR TITLE
Fix: typo in error message for state_dict validation

### DIFF
--- a/src/mistral_inference/lora.py
+++ b/src/mistral_inference/lora.py
@@ -111,7 +111,7 @@ class LoRALoaderMixin:
         lora_dtypes = set([p.dtype for p in lora_state_dict.values()])
         assert (
             len(lora_dtypes) == 1
-        ), f"LoRA weights have multipe different dtypes {lora_dtypes}. All weights need to have the same dtype"
+        ), f"LoRA weights have multiple different dtypes {lora_dtypes}. All weights need to have the same dtype"
         lora_dtype = lora_dtypes.pop()
         assert (
             lora_dtype == self.dtype


### PR DESCRIPTION
Corrected a typo in the error message within the _load_lora_state_dict method of the LoRALoaderMixin class. The word "multipe" was changed to "multiple" to ensure clarity and accuracy in error reporting. This change improves the readability and professionalism of the codebase.