### PR TITLE
fix: typo in LoRALoaderMixin: correct "multipe" to "multiple"

### DIFF
--- a/src/mistral_inference/lora.py
+++ b/src/mistral_inference/lora.py
@@ -111,7 +111,7 @@ class LoRALoaderMixin:
         lora_dtypes = set([p.dtype for p in lora_state_dict.values()])
         assert (
             len(lora_dtypes) == 1
-        ), f"LoRA weights have multipe different dtypes {lora_dtypes}. All weights need to have the same dtype"
+        ), f"LoRA weights have multiple different dtypes {lora_dtypes}. All weights need to have the same dtype"
         lora_dtype = lora_dtypes.pop()
         assert (
             lora_dtype == self.dtype


### PR DESCRIPTION
Corrected a typographical error in the `_load_lora_state_dict` method of the `LoRALoaderMixin` class. The word "multipe" was corrected to "multiple" in the assertion message that checks for consistent data types in the LoRA state dictionary.