### PR TITLE
Fix: typo in ModelArgs: "infered" to "inferred"

### DIFF
--- a/src/mistral_inference/model.py
+++ b/src/mistral_inference/model.py
@@ -35,7 +35,7 @@ class ModelArgs(Serializable):
 
     max_batch_size: int = 0
 
-    # For rotary embeddings. If not set, will be infered
+    # For rotary embeddings. If not set, will be inferred
     rope_theta: Optional[float] = None
     # If this is set, we will use MoE layers instead of dense layers.
     moe: Optional[MoeArgs] = None


### PR DESCRIPTION
Corrected a typographical error in the `ModelArgs` class of the inference script. The word "infered" was corrected to "inferred" in the comment regarding rotary embeddings.