### PR TITLE
fix: typo in .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ MANIFEST
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+#  before PyInstaller builds the exe, so as to inject date/other info into it.
 *.manifest
 *.spec
 


### PR DESCRIPTION
Corrected a typo in the .gitignore file. Changed "infos" to "info" for grammatical accuracy.