### PR TITLE
fix: typo in HF_TOKEN environment variable check message

### DIFF
--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ ! -z "${HF_TOKEN}" ]]; then
-    echo "The HF_TOKEN environment variable set, logging to Hugging Face."
+    echo "The HF_TOKEN environment variable is set, logging to Hugging Face."
     python3 -c "import huggingface_hub; huggingface_hub.login('${HF_TOKEN}')"
 else
     echo "The HF_TOKEN environment variable is not set or empty, not logging to Hugging Face."


### PR DESCRIPTION
Fixed a typo in the bash script that logs into Hugging Face using the HF_TOKEN environment variable. The message now correctly states "The HF_TOKEN environment variable is set" instead of "The HF_TOKEN environment variable set".