### PR TITLE
Correct grammatical error in markdown cells

### DIFF
--- a/tutorials/getting_started.ipynb
+++ b/tutorials/getting_started.ipynb
@@ -152,7 +152,7 @@
     "                        \"format\": {\n",
     "                            \"type\": \"string\",\n",
     "                            \"enum\": [\"celsius\", \"fahrenheit\"],\n",
-    "                            \"description\": \"The temperature unit to use. Infer this from the users location.\",\n",
+    "                            \"description\": \"The temperature unit to use. Infer this from the user's location.\",\n",
     "                        },\n",
     "                    },\n",
     "                    \"required\": [\"location\", \"format\"],\n",


### PR DESCRIPTION
Fixed the grammatical error in the markdown cell by changing "users location" to the possessive "user's location".