### PR TITLE
Update hardcoded Mamba filenames

### DIFF
--- a/src/mistral_inference/mamba.py
+++ b/src/mistral_inference/mamba.py
@@ -68,13 +68,13 @@ class Mamba(ModelBase, nn.Module):
         device: Union[torch.device, str] = "cuda",
         dtype: Optional[torch.dtype] = None,
     ) -> "Mamba":
-        with open(Path(folder) / "params.json", "r") as f:
+        with open(Path(folder) / "config.json", "r") as f:
             model_args = MambaArgs.from_dict(json.load(f))
 
         with torch.device("meta"):
             model = Mamba(model_args)
 
-        model_file = Path(folder) / "consolidated.safetensors"
+        model_file = Path(folder) / "model.safetensors"
 
         assert model_file.exists(), f"Make sure {model_file} exists."
         loaded = safetensors.torch.load_file(str(model_file))


### PR DESCRIPTION
`mamba_ssm` has already hardcoded the filenames for the config and weights files in https://github.com/Wauplin/mamba/blob/33dc96c84926e58a392861d5ad9d2ee4f4f4a259/mamba_ssm/utils/hf.py. It uses the convention for the Hugging Face Hub which is usually `config.json` for config and `model.safetensors` for weights. This PR updates `mistral-inference` to comply with this and make the model loadable from `mamba_ssm` directly. It would require the filenames to be renamed on the HF Hub repo.

This change would also allow the download counter to work on the model page out of the box.