### PR TITLE
add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,69 @@
+# base path
+ROOT_DIR_WITH_SLASH := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+MISTRAL_MODELS_PATH = $(ROOT_DIR_WITH_SLASH)mistral_models
+
+# download from:
+CODESTRAL_MAMBA_URL = https://models.mistralcdn.com/codestral-mamba-7b-v0-1/codestral-mamba-7B-v0.1.tar
+MISTRAL_7B_3_URL = https://models.mistralcdn.com/mistral-7b-v0-3/mistral-7B-Instruct-v0.3.tar
+MATHSTRAL_7B_URL = https://models.mistralcdn.com/mathstral-7b-v0-1/mathstral-7B-v0.1.tar
+
+# download to:
+CODESTRAL_MAMBA_TAR_PATH = $(MISTRAL_MODELS_PATH)/codestral-mamba-7B-v0.1.tar
+MISTRAL_7B_3_TAR_PATH = $(MISTRAL_MODELS_PATH)/mistral-7B-Instruct-v0.3.tar
+MATHSTRAL_7B_TAR_PATH = $(MISTRAL_MODELS_PATH)/mathstral-7B-v0.1.tar
+
+# extract to:
+CODESTRAL_MAMBA_DIR_PATH = $(MISTRAL_MODELS_PATH)/codestral-mamba-7B-v0.1
+MISTRAL_7B_3_DIR_PATH = $(MISTRAL_MODELS_PATH)/mistral-7B-Instruct-v0.3
+MATHSTRAL_7B_DIR_PATH = $(MISTRAL_MODELS_PATH)/mathstral-7B-v0.1
+
+
+.PHONY: mistral-models download-mistral extract-mistral
+
+mistral-models: download-mistral extract-mistral
+
+# Download the .tar files
+download-mistral: \
+	$(MISTRAL_MODELS_PATH)/codestral-mamba-7B-v0.1.tar \
+	$(MISTRAL_MODELS_PATH)/mistral-7B-Instruct-v0.3.tar \
+	$(MISTRAL_MODELS_PATH)/mathstral-7B-v0.1.tar
+
+$(CODESTRAL_MAMBA_TAR_PATH):
+	@echo "Downloading Codestral Mamba model..."
+	mkdir -p $(MISTRAL_MODELS_PATH)
+	wget -P $(MISTRAL_MODELS_PATH) $(CODESTRAL_MAMBA_URL)
+
+$(MISTRAL_7B_3_TAR_PATH):
+	@echo "Downloading Mistral 7B model..."
+	mkdir -p $(MISTRAL_MODELS_PATH)
+	wget -P $(MISTRAL_MODELS_PATH) $(MISTRAL_7B_3_URL)
+
+$(MATHSTRAL_7B_TAR_PATH):
+	@echo "Downloading Mathstral 7B model..."
+	mkdir -p $(MISTRAL_MODELS_PATH)
+	wget -P $(MISTRAL_MODELS_PATH) $(MATHSTRAL_7B_URL)
+
+# Extract the .tar files to the target dir_paths
+extract-mistral: \
+	$(CODESTRAL_MAMBA_DIR_PATH) \
+	$(MISTRAL_7B_3_DIR_PATH) \
+	$(MATHSTRAL_7B_DIR_PATH)
+
+$(CODESTRAL_MAMBA_DIR_PATH): $(CODESTRAL_MAMBA_TAR_PATH)
+	@echo "Extracting Codestral Mamba model..."
+	mkdir -p $(CODESTRAL_MAMBA_DIR_PATH)
+	tar -xf $(CODESTRAL_MAMBA_TAR_PATH) -C $(CODESTRAL_MAMBA_DIR_PATH)
+
+$(MISTRAL_7B_3_DIR_PATH): $(MISTRAL_7B_3_TAR_PATH)
+	@echo "Extracting Mistral 7B model..."
+	mkdir -p $(MISTRAL_7B_3_DIR_PATH)
+	tar -xf $(MISTRAL_7B_3_TAR_PATH) -C $(MISTRAL_7B_3_DIR_PATH)
+
+$(MATHSTRAL_7B_DIR_PATH): $(MATHSTRAL_7B_TAR_PATH)
+	@echo "Extracting Mistral 7B model..."
+	mkdir -p $(MATHSTRAL_7B_DIR_PATH)
+	tar -xf $(MATHSTRAL_7B_TAR_PATH) -C $(MATHSTRAL_7B_DIR_PATH)
+
+clean-mistral:
+	rm -rf $(MISTRAL_MODELS_PATH)/*
+


### PR DESCRIPTION
this Makefile enables developers to download and extract three Mistral open source models with a single word: `make`

Models included:
- codestral-mamba-7b-v0-1
- mistral-7b-v0-3
- mathstral-7b-v0-1

Note: there would still be some additional setup needed, specifically to [tell the mistral-chat CLI where to find the models](https://github.com/mistralai/mistral-inference/tree/main?tab=readme-ov-file#usage)

If it's helpful, I can help update the README to show how to use the makefile
We can also have the makefile install and run the cli
We can even make it idempotently add `mistral-models` to the `$PATH` by adding code to their `profile` (example: https://github.com/bionicles/tree_plus/blob/main/tree_plus_src/scripts/alias_tree_plus.sh)

inlined here and lightly modified to save you a click
```sh
#!/bin/bash

# set your RC_FILE to .bashrc if you use bash 
# or set it to .zshrc if you use zsh
RC_FILE=~/.bash_profile # where the aliases will be added

# Function to idempotently add an alias if it doesn't exist in RC_FILE
add_alias() {
    grep -qF "alias $1=\"$2\"" $RC_FILE || echo "alias $1=\"$2\"" >> $RC_FILE
}

# Add alias
add_alias mc mistral-chat 
```

ah here's another nice script chunk that would enable the one above to automatically add a line to the user's profile which would indicate the path to find the mistral_models

```sh
export DEBUG=true

# ensure lines are added to a file only once
function idempotent_add_line_to_file() {
  local line="$1"
  local file="$2"
  # Check if the line already exists in the file
  if grep -Fxq "$line" "$file"; then
    ${DEBUG:=false} && echo "DEBUG(idempotent_add_line_to_file) line '$line' already in '$file'"
  else
    echo "$line" >> "$file"
    echo "DEBUG(idempotent_add_line_to_file) SCRIPT_DIR: $SCRIPT_DIR"
    echo "The line '$line' was added to '$file'"
  fi
}
SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
echo "DEBUG(idempotent_add_line_to_file) SCRIPT_DIR: $SCRIPT_DIR"
idempotent_add_line_to_file "export MISTRAL_MODELS_PATH=$SCRIPT_DIR/mistral_models" "$HOME/$RC_FILE"
export -f idempotent_add_line_to_file
```
key idea: it only adds the line once, so it won't keep re-adding it

could enable mistral to install local terminal utilities more easily without needing to tell people to tinker with their path too much

Anyway: TLDR - make it easier to download the models, and this description contains a couple of bash fragments to make it even easier