### PR TITLE
Fix device error when using cuda device other than cuda:0

### DIFF
--- a/src/mistral_inference/cache.py
+++ b/src/mistral_inference/cache.py
@@ -179,7 +179,7 @@ class BufferCache:
             assert all([pos == 0 for pos in seqpos]), seqpos
             mask = BlockDiagonalCausalMask.from_seqlens(
                 seqlens,
-                device=self.device
+                device=self.device,
             ).make_local_attention(self.max_seq_len)
         elif subsequent_prefill:
             mask = BlockDiagonalMask.from_seqlens(
@@ -187,14 +187,14 @@ class BufferCache:
                 kv_seqlen=[
                     s + cached_s.clamp(max=self.max_seq_len).item() for (s, cached_s) in zip(seqlens, self.kv_seqlens)
                 ],
-                device=self.device
+                device=self.device,
             ).make_local_attention_from_bottomright(self.max_seq_len)
         else:
             mask = BlockDiagonalCausalWithOffsetPaddedKeysMask.from_seqlens(
                 q_seqlen=seqlens,
                 kv_padding=self.max_seq_len,
                 kv_seqlen=(self.kv_seqlens + cached_elements).clamp(max=self.max_seq_len).tolist(),
-                device=self.device
+                device=self.device,
             )
 
         return CacheInputMetadata(


### PR DESCRIPTION
Fixes https://github.com/mistralai/mistral-inference/issues/215

Attention bias was being created on cuda:0 regardless of the selected cuda device as the correct device was not being passed to `from_seqlens()` in `BufferCache.get_input_metadata()`