### PR TITLE
[fix] Correctly pass mask in TransformerBlock.forward in transformer_layers.py

### DIFF
--- a/src/mistral_inference/transformer_layers.py
+++ b/src/mistral_inference/transformer_layers.py
@@ -162,7 +162,7 @@ class TransformerBlock(nn.Module):
         cache: Optional[CacheView] = None,
         mask: Optional[BlockDiagonalMask] = None,
     ) -> torch.Tensor:
-        r = self.attention.forward(self.attention_norm(x), freqs_cis, cache)
+        r = self.attention.forward(x=self.attention_norm(x), freqs_cis=freqs_cis, cache=cache, mask=mask)
         h = x + r
         r = self.feed_forward.forward(self.ffn_norm(h))
         out = h + r


### PR DESCRIPTION
The attention mask was not passed correctly to the `Attention` in `TransformerBlock.forward`.

One problem it caused was that when passing two images in the image encoder, the attention would be done on all images at the same time, thus taking more resources and returning an incorrect result.

This PR fixes this problem.
Tested by passing two images separately to the encoder, and checking that passing them as a batch gives "almost" the same thing.
Also tested on classic vision benchmarks where the results were very low (and inference very slow), now considerably better:
ImageNet KNN:
- was 7.27% accuracy and took 5h
- now is 63.79% accuracy and takes 35 min (8.6 times faster)
