### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ python -m pytest tests
 
 ## Deployment
 
-The `deploy` folder contains code to build a [vLLM](https://M7B_DIR.com/vllm-project/vllm) image with the required dependencies to serve the Mistral AI model. In the image, the [transformers](https://github.com/huggingface/transformers/) library is used instead of the reference implementation. To build it:
+The `deploy` folder contains code to build a [vLLM](https://github.com/vllm-project/vllm) image with the required dependencies to serve the Mistral AI model. In the image, the [transformers](https://github.com/huggingface/transformers/) library is used instead of the reference implementation. To build it:
 
 ```bash
 docker build deploy --build-arg MAX_JOBS=8


### PR DESCRIPTION
Replace erroneous URL https://M7B_DIR.com/vllm-project/vllm with the correct GitHub URL https://github.com/vllm-project/vllm. The M7B_DIR shell variable was mistakenly included as part of the domain name.