### PR TITLE
feat(model-service): add OpenAI-compatible wrapper (+ pm2 + env example) and update ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,4 +159,4 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 model-service/.env
-model-service/.env
+

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+model-service/.env
+model-service/.env

--- a/model-service/.env.example
+++ b/model-service/.env.example
@@ -1,0 +1,5 @@
+OPENAI_BASE_URL=https://api.openai.com/v1
+OPENAI_API_KEY=sk-REPLACE_ME
+MODEL_NAME=gpt-4o-mini
+PORT=7071
+

--- a/model-service/.gitignore
+++ b/model-service/.gitignore
@@ -1,0 +1,5 @@
+package-lock.json
+node_modules/
+.env
+.DS_Store
+

--- a/model-service/Procfile
+++ b/model-service/Procfile
@@ -1,0 +1,2 @@
+web: node server.js
+

--- a/model-service/ecosystem.config.js
+++ b/model-service/ecosystem.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+  apps: [
+    {
+      name: 'reentry-model-service',
+      script: 'server.js',
+      instances: 1,
+      exec_mode: 'fork',
+      env: {
+        // server.js loads dotenv; these are optional overrides
+        PORT: process.env.PORT || 7071,
+      },
+      watch: false,
+    },
+  ],
+};
+

--- a/model-service/package.json
+++ b/model-service/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "reentry-model-service",
+  "version": "1.0.0",
+  "private": true,
+  "main": "server.js",
+  "license": "UNLICENSED",
+  "scripts": {
+    "dev": "node server.js",
+    "start": "node server.js",
+    "pm2": "pm2 start ecosystem.config.js"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "node-fetch": "^2.7.0"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/model-service/server.js
+++ b/model-service/server.js
@@ -1,0 +1,64 @@
+const express = require('express');
+const fetch = require('node-fetch');
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+const app = express();
+app.use(express.json());
+
+const PORT = process.env.PORT || 7071;
+const OPENAI_BASE_URL = (process.env.OPENAI_BASE_URL || 'https://api.openai.com/v1').replace(/\/+$/, '');
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY || '';
+const MODEL_NAME = process.env.MODEL_NAME || 'gpt-4o-mini';
+
+// Health endpoint
+app.get('/health', (_req, res) => {
+  res.json({ ok: true, model: MODEL_NAME, base: OPENAI_BASE_URL });
+});
+
+// Generate endpoint - forwards to provider-compatible chat/completions
+app.post('/generate', async (req, res) => {
+  try {
+    if (!OPENAI_API_KEY) {
+      return res.status(400).json({ error: 'Missing OPENAI_API_KEY in environment' });
+    }
+
+    const body = req.body || {};
+    const messages = body.messages;
+    const model = body.model || MODEL_NAME;
+    const extra = body.extra || {}; // allow optional pass-through params
+
+    if (!Array.isArray(messages) || messages.length === 0) {
+      return res.status(400).json({ error: 'Body must include messages: [{ role, content }]' });
+    }
+
+    const url = `${OPENAI_BASE_URL}/chat/completions`;
+
+    const providerResp = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${OPENAI_API_KEY}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ model, messages, ...extra })
+    });
+
+    const data = await providerResp.json();
+
+    if (!providerResp.ok) {
+      // Pass through provider error
+      return res.status(providerResp.status).json({ error: data.error || data });
+    }
+
+    const text = data?.choices?.[0]?.message?.content || '';
+    return res.json({ text });
+  } catch (err) {
+    return res.status(500).json({ error: 'Upstream error', detail: String(err && err.message || err) });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`model-service listening on http://localhost:${PORT}`);
+});
+


### PR DESCRIPTION


PR title

feat(model-service): add OpenAI-compatible wrapper (+ pm2 + env example) and update ignores

PR body 

## Summary
This PR adds a minimal **Node/Express model-service** that exposes:
- `GET /health` → returns `{ ok, model, base }`
- `POST /generate` → forwards `messages` to `${OPENAI_BASE_URL}/chat/completions` and returns `{ text }`

The wrapper is **provider-agnostic** (OpenAI, Mistral API, OpenRouter, etc.) via `.env`.

### What changed
- `model-service/server.js` – Express service with `/health` and `/generate`, reads `.env` via `dotenv` [oai_citation:0‡server.js](file-service://file-JURuk7mmAVcVM2WEGWCpAq)  
- `model-service/package.json` – scripts: `dev`, `start`, `pm2`; Node ≥ 18 engines [oai_citation:1‡package.json](file-service://file-Wtgi461xhjnUh6YWMGhSGr)  
- `model-service/.env.example` – starter env for provider URL/key/model/port  
- `model-service/ecosystem.config.js` – pm2 process file (`npm run pm2`) [oai_citation:2‡ecosystem.config.js](file-service://file-MUyPrTm6wz1YxU9V2q7Lok)  
- `model-service/Procfile` – proc entry for platforms that use Procfile  
- Root `.gitignore` – ignore `model-service/.env` (secrets not committed)

### Why
- Gives contributors and students a **local OpenAI-compatible endpoint** without changing app code when switching providers.
- Keeps the interface stable while we iterate on infra (hosted or self-hosted later).

### How to run (reviewer quick start)
```bash
cd model-service
cp .env.example .env     # paste your provider key
npm install
npm run dev
curl http://localhost:7071/health
curl -s -X POST http://localhost:7071/generate \
  -H "Content-Type: application/json" \
  -d '{"messages":[{"role":"user","content":"Say hello from Second Story!"}]}'

Env configuration

OPENAI_BASE_URL=https://api.openai.com/v1     # or https://api.mistral.ai/v1, https://openrouter.ai/api/v1
OPENAI_API_KEY=sk-REPLACE_ME
MODEL_NAME=gpt-4o-mini                        # or mistral-small, openai/gpt-4o-mini, etc.
PORT=7071

Notes
	•	Node ≥ 18 required (declared in package.json engines). ￼
	•	pm2 run supported:

npm run pm2
pm2 logs reentry-model-service

(Process config in ecosystem.config.js.) ￼

Testing done
	•	GET /health returns {"ok":true,"model":"...", "base":"..."}
	•	POST /generate returns { "text": "..." } round-tripped from provider.
	•	Verified .env is ignored and not committed.

Follow-ups (separate PRs)
	•	Add scripts/test-model.sh convenience script and student_setup.md
	•	Add CI job to npm i && node -v && curl /health
	•	Optional: add /api RAG layer with citations

---

### Labels to apply
- `type: feat`
- `area: inference` (or `area: model-service`)
- `ready for review`

### Reviewers to request
- Anyone responsible for infra/dev-tools in your org.