### PR TITLE
Fixing MAX_JOBS in Dockerfile, resolving issue #91

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -14,6 +14,11 @@ ENV TORCH_CUDA_ARCH_LIST "7.0;7.2;7.5;8.0;8.6;8.9;9.0"
 RUN pip3 install "torch==2.1.1"
 
 # This build is slow but NVIDIA does not provide binaries. Increase MAX_JOBS as needed.
+# MAX_JOBS needs to be passed into the container by ENV but is defined before as ARG to
+# make it possible to configure it at build time with "--build-arg MAX_JOBS=x".
+ARG MAX_JOBS
+ENV MAX_JOBS=$MAX_JOBS
+
 RUN pip3 install "git+https://github.com/stanford-futuredata/megablocks.git"
 RUN pip3 install "git+https://github.com/vllm-project/vllm.git"
 RUN pip3 install "xformers==0.0.23" "transformers==4.36.0" "fschat[model_worker]==0.2.34"


### PR DESCRIPTION
Hej,

after running into OOM, I fixed the MAX_JOBS issue #91. The only file that needed to be modified is the Dockerfile.

_Explanation_
Build arguments (ARG) are only visible at Dockerfile level, they're not passed through into the container. Therefor MAX_JOBS needs to be passed to the container as environment variable which only can be done bei ENV. That, on the other hand, cannot be overriden by a command line option like "--build-arg" (there's no "--build-env").

To be configurable, it needs to be defined as ARG first and then set with ENV while refering to the ARG:
```
ARG MAX_JOBS
ENV MAX_JOBS=$MAX_JOBS

RUN pip3 install ...
```

_Med hilsen fra Danmark_
