### PR TITLE
Fix a broken Dockerfile and reduce the final image size using a  multi-stage build

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,31 +1,67 @@
-FROM --platform=amd64 nvcr.io/nvidia/cuda:12.1.0-devel-ubuntu22.04 as base
+FROM --platform=amd64 nvidia/cuda:12.1.0-devel-ubuntu22.04 AS builder
+
+ARG MAX_JOBS=4
+ENV MAX_JOBS=${MAX_JOBS}
 
 WORKDIR /workspace
 
-RUN apt update && \
-    apt install -y python3-pip python3-packaging \
-    git ninja-build && \
-    pip3 install -U pip
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        python3-pip \
+        python3-packaging \
+        python3-venv \
+        python3-dev \
+        git \
+        ninja-build && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+RUN pip install --no-cache-dir -U pip
 
 # Tweak this list to reduce build time
 # https://developer.nvidia.com/cuda-gpus
-ENV TORCH_CUDA_ARCH_LIST "7.0;7.2;7.5;8.0;8.6;8.9;9.0"
+ENV TORCH_CUDA_ARCH_LIST="7.0;7.2;7.5;8.0;8.6;8.9;9.0"
 
-RUN pip3 install "torch==2.1.1"
+# torch in its own layer for reusable cache
+RUN pip install --no-cache-dir "torch==2.4.0"
 
-# This build is slow but NVIDIA does not provide binaries. Increase MAX_JOBS as needed.
-RUN pip3 install "git+https://github.com/stanford-futuredata/megablocks.git"
-RUN pip3 install "git+https://github.com/vllm-project/vllm.git"
-RUN pip3 install "xformers==0.0.23" "transformers==4.36.0" "fschat[model_worker]==0.2.34"
+RUN pip install --no-cache-dir "wheel" "numpy"
+
+RUN pip install --no-cache-dir --no-build-isolation \
+    "megablocks==0.6.1" \
+    "vllm==0.5.5" \
+    "transformers==4.44.0" \
+    "fschat[model_worker]==0.2.36"
 
 RUN git clone https://github.com/NVIDIA/apex && \
-    cd apex && git checkout 2386a912164b0c5cfcd8be7a2b890fbac5607c82 && \
+    cd apex && \
+    git checkout 2386a912164b0c5cfcd8be7a2b890fbac5607c82 && \
     sed -i '/check_cuda_torch_binary_vs_bare_metal(CUDA_HOME)/d' setup.py && \
     python3 setup.py install --cpp_ext --cuda_ext
 
 
+FROM --platform=amd64 nvidia/cuda:12.1.0-runtime-ubuntu22.04 AS runtime
+
+WORKDIR /workspace
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        python3 \
+        python3-venv && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /opt/venv /opt/venv
+
+ENV PATH="/opt/venv/bin:$PATH"
+
 COPY entrypoint.sh .
 
-RUN chmod +x /workspace/entrypoint.sh
+RUN chmod +x /workspace/entrypoint.sh && \
+    useradd -m -u 1000 mistral && \
+    chown -R mistral:mistral /workspace
+
+USER mistral
 
 ENTRYPOINT ["/workspace/entrypoint.sh"]


### PR DESCRIPTION
The existing Dockerfile cannot be built on modern hardware. It installs vllm and megablocks directly from their git main branches with no version pins. When the Dockerfile was written (~2023), vllm was a relatively small project. Today it compiles 189 CUDA files and needs 32GB+ RAM to build from source. On standard hardware the build fails with exit code 137 (OOM) before it even finishes.

Additionally, the base image is pulled from nvcr.io which requires an NVIDIA NGC account. This breaks the build silently for anyone who hasn't logged in, which is most open source contributors.

**Multi-stage build**
The original used `cuda:devel` as the final base image. This ships the entire CUDA compiler toolchain (~3.7GB) in the runtime image even though nothing needs to compile at runtime. The new Dockerfile uses a builder stage for compilation and a separate `cuda:runtime` stage for the final image.

**Base image registry**
Switched from `nvcr.io/nvidia/cuda` to `nvidia/cuda` (Docker Hub mirror). Identical images, no authentication required.

**Dependency pins**
Replaced unpinned git sources with pinned PyPI versions:
- `git+vllm` → `vllm==0.5.5` (pre-built wheel, no source compilation)
- `git+megablocks` → `megablocks==0.6.1`
- `torch==2.1.1` → `torch==2.4.0`
- `transformers==4.36.0` → `transformers==4.44.0`
- `xformers==0.0.23` → managed by vllm as transitive dependency

Note: upgrading the full stack was necessary because megablocks PyPI releases >= 0.5.0 require `torch >= 2.3.0` via their `stanford-stk` dependency. There is no PyPI version of megablocks compatible with `torch==2.1.1`, so a full stack upgrade was the only path to avoiding git sources.

**Security**
Added a non-root user (`mistral`, uid 1000). Running as root inside containers is unnecessary for inference serving and increases blast radius if the container is compromised.

## Tested on

Built and verified locally on macOS with Docker Desktop (Linux/amd64  emulation). Full build time ~48 minutes, final image size 14.4GB.

```
docker build -t mistral-inference-opt .  5.89s user 6.11s system 0% cpu 48:03.45 total
% docker images
REPOSITORY              TAG       IMAGE ID       CREATED         SIZE
mistral-inference-opt   latest    0f362b5fbe9c   4 minutes ago   14.4GB
```