### PR TITLE
fix(readme): correct broken vLLM link in deploy section

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ python -m pytest tests
 
 ## Deployment
 
-The `deploy` folder contains code to build a [vLLM](https://M7B_DIR.com/vllm-project/vllm) image with the required dependencies to serve the Mistral AI model. In the image, the [transformers](https://github.com/huggingface/transformers/) library is used instead of the reference implementation. To build it:
+The `deploy` folder contains code to build a [vLLM](https://github.com/vllm-project/vllm) image with the required dependencies to serve the Mistral AI model. In the image, the [transformers](https://github.com/huggingface/transformers/) library is used instead of the reference implementation. To build it:
 
 ```bash
 docker build deploy --build-arg MAX_JOBS=8


### PR DESCRIPTION
## Summary

The vLLM hyperlink in the **Deployment** section of `README.md` points to an invalid URL:

```
https://M7B_DIR.com/vllm-project/vllm
```

This appears to be caused by the shell variable `$M7B_DIR` (used elsewhere in the README for model directory paths) being inadvertently expanded into the URL domain, replacing `github` with the variable name `M7B_DIR`.

## Changes

- Replaced `https://M7B_DIR.com/vllm-project/vllm` with `https://github.com/vllm-project/vllm`

## Verification

- Confirmed the broken link returns a DNS resolution failure (unreachable domain)
- Confirmed the corrected link (`https://github.com/vllm-project/vllm`) resolves to HTTP 200
- No other files are affected by this change