### PR TITLE
fix: move length_tensor to CUDA before NCCL broadcast in distributed inference

### DIFF
--- a/src/mistral_inference/main.py
+++ b/src/mistral_inference/main.py
@@ -109,7 +109,8 @@ def interactive(
 ) -> None:
     if is_torchrun():
         torch.distributed.init_process_group()
-        torch.cuda.set_device(torch.distributed.get_rank())
+        local_rank = int(os.environ.get("LOCAL_RANK", str(torch.distributed.get_rank())))
+        torch.cuda.set_device(local_rank)
         should_print = torch.distributed.get_rank() == 0
 
         num_pipeline_ranks = torch.distributed.get_world_size()
@@ -164,6 +165,8 @@ def interactive(
             images = []
 
         if is_torchrun():
+            if dist.is_initialized() and dist.get_backend() == "nccl":
+                length_tensor = length_tensor.cuda()
             dist.broadcast(length_tensor, src=0)
 
         if not should_print:
@@ -208,7 +211,8 @@ def demo(
 ) -> None:
     if is_torchrun():
         torch.distributed.init_process_group()
-        torch.cuda.set_device(torch.distributed.get_rank())
+        local_rank = int(os.environ.get("LOCAL_RANK", str(torch.distributed.get_rank())))
+        torch.cuda.set_device(local_rank)
         should_print = torch.distributed.get_rank() == 0
 
         num_pipeline_ranks = torch.distributed.get_world_size()


### PR DESCRIPTION
## Description

Fixes the `RuntimeError: No backend type associated with device type cpu` error that occurs during distributed inference with NCCL backend.

## Root Cause

In `main.py`, `length_tensor` is created on CPU (`torch.tensor([len(tokens)], dtype=torch.int)`) and passed directly to `dist.broadcast()`. NCCL only supports CUDA tensors, causing the error on multi-GPU setups.

## Fix

- Move `length_tensor` to CUDA before calling `dist.broadcast()` when using NCCL backend
- Use `LOCAL_RANK` instead of global `RANK` for `torch.cuda.set_device()` to support multi-node configurations

## Testing

This fix addresses the exact scenario described in #252. The change is conservative — it only moves the tensor to CUDA when NCCL is detected, preserving compatibility with other backends (e.g., Gloo for CPU-only setups).

Fixes #252
Related: #257 (alternative approach)