### PR TITLE
fix: pass explicit device to attention mask creation in cache

### DIFF
--- a/src/mistral_inference/cache.py
+++ b/src/mistral_inference/cache.py
@@ -237,7 +237,7 @@ class BufferCache:
         subsequent_prefill = any(seqlen > 1 for seqlen in seqlens)
         if first_prefill:
             assert all([pos == 0 for pos in seqpos]), seqpos
-            mask = BlockDiagonalCausalMask.from_seqlens(seqlens).make_local_attention(cache_size)
+            mask = BlockDiagonalCausalMask.from_seqlens(seqlens, device=self.device).make_local_attention(cache_size)
         elif subsequent_prefill:
             assert self.kv_seqlens is not None
             mask = BlockDiagonalMask.from_seqlens(
@@ -245,12 +245,14 @@ class BufferCache:
                 kv_seqlen=[
                     s + cached_s.clamp(max=cache_size).item() for (s, cached_s) in zip(seqlens, self.kv_seqlens)
                 ],
+                device=self.device,
             ).make_local_attention_from_bottomright(cache_size)
         else:
             mask = BlockDiagonalCausalWithOffsetPaddedKeysMask.from_seqlens(
                 q_seqlen=seqlens,
                 kv_padding=cache_size,
                 kv_seqlen=(self.kv_seqlens + cached_elements).clamp(max=cache_size).tolist(),
+                device=self.device,
             )
         return CacheInputMetadata(
             positions=positions,


### PR DESCRIPTION
## Description

Fixes the `ValueError: Attention bias and Query/Key/Value should be on the same device` error that occurs when loading a model on a non-default CUDA device (e.g., `cuda:7`).

## Root Cause

In `cache.py`, the attention masks created by `BlockDiagonalCausalMask.from_seqlens()` and related calls don't receive an explicit `device` parameter. They default to `cuda:0`, causing a device mismatch when the model runs on a different GPU.

## Fix

Pass `device=self.device` to all `from_seqlens()` calls in the cache module, ensuring attention masks are created on the same device as the model.

## Credit

This is an updated version of #216 by @cornzz, adapted to the current codebase after the cache refactoring.

Fixes #215
Related: #216 (original fix, now in conflict)