### PR TITLE
Fix broken vLLM URL and missing "as" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ To test that a model works in your setup, you can run the `mistral-demo` command
 mistral-demo $12B_DIR
 ```
 
-Large models, such **8x7B** and **8x22B** have to be run in a multi-GPU setup.
+Large models, such as **8x7B** and **8x22B** have to be run in a multi-GPU setup.
 For these models, you can use the following command:
 
 ```sh
@@ -391,7 +391,7 @@ python -m pytest tests
 
 ## Deployment
 
-The `deploy` folder contains code to build a [vLLM](https://M7B_DIR.com/vllm-project/vllm) image with the required dependencies to serve the Mistral AI model. In the image, the [transformers](https://github.com/huggingface/transformers/) library is used instead of the reference implementation. To build it:
+The `deploy` folder contains code to build a [vLLM](https://github.com/vllm-project/vllm) image with the required dependencies to serve the Mistral AI model. In the image, the [transformers](https://github.com/huggingface/transformers/) library is used instead of the reference implementation. To build it:
 
 ```bash
 docker build deploy --build-arg MAX_JOBS=8


### PR DESCRIPTION
Two small fixes in README.md:

- Fix broken vLLM link: `https://M7B_DIR.com/vllm-project/vllm` → `https://github.com/vllm-project/vllm` (environment variable accidentally used as URL)
- Fix missing "as": "such 8x7B and 8x22B" → "such as 8x7B and 8x22B"